### PR TITLE
link to python notebook as a markdown file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    *.tox*
+

--- a/bsyncviewer/templates/technical_resources.html
+++ b/bsyncviewer/templates/technical_resources.html
@@ -11,7 +11,7 @@
 	<h3>Guides</h3>
 	<div class="list">
 		<ul>
-			<li><a href="https://nbviewer.jupyter.org/github/BuildingSync/schema/blob/develop-v2/docs/notebooks/bsync_examples/Small-Office-Level-1.ipynb"><b>Energy Auditing with BuildingSync</b></a>: an interactive introduction to what BuildingSync is and how it relates to buildings, building systems, and energy audit reporting.</li>
+			<li><a href="https://github.com/BuildingSync/schema/blob/develop-v2/docs/notebooks/bsync_examples/Small-Office-Level-1.md"><b>Energy Auditing with BuildingSync</b></a>: an interactive introduction to what BuildingSync is and how it relates to buildings, building systems, and energy audit reporting.</li>
 			<li><a href="{% static 'documents/BuildingSync-on-boarding.pdf' %}"><b>BuildingSync On-boarding Guide</b></a>: a PDF documenting BuildingSync Use Cases, their implementation and publication.</li>
 		</ul>
 	</div>


### PR DESCRIPTION
We've migrated the notebook from ipynb to a markdown, thus we need to update this link. Github views markdown files natively, so just link off to github now.

Link is the first on this page: https://buildingsync.net/technical_resources

@kflemin can you deploy after this is approved and merged? Grazie. 