### PR TITLE
Upgrade to Python 3.7.10 by bumping alpine to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # AUTHOR:           Nicholas Long <nicholas.long@nrel.gov>
 # DESCRIPTION:      Dockerfile for running BuildingSync Data Selection Tool
 # TO_BUILD_AND_RUN: docker-compose build && docker-compose up
-FROM alpine:3.8
+FROM alpine:3.10
 
 RUN apk add --no-cache python3 \
         python3-dev \


### PR DESCRIPTION
Alpine 3.8 was still on Python < 3.7 which breaks many newer dependencies.